### PR TITLE
Improved code

### DIFF
--- a/src/capsule/capsule.did
+++ b/src/capsule/capsule.did
@@ -27,4 +27,5 @@ service : {
     ) -> (Result_1);
   purchase_skill_nft : (nat64) -> (Result);
   set_resale_price : (nat64, nat64) -> (Result);
+  transfer_nft_ownership : (nat64, principal) -> (Result);
 }


### PR DESCRIPTION
### Hello Gocx,

Overall, the implementation was excellent, and I loved how thoughtful and methodical the approach was. With the suggested improvements and additional features, this codebase could serve as a strong foundation for a robust and scalable NFT system.
Keep up the amazing work!


Here is a detailed list of all the changes and improvements made to the original code:

---

### 1. **Input Validation**

- **Minting NFTs**: Added a helper function `validate_input` to validate the `title`, `description`, and `price` inputs.
    - Ensures `title` and `description` are non-empty.
    - Ensures `price` is greater than zero.
- **Setting Resale Price**: Added validation to ensure the resale price is greater than zero.

---

### 2. **Unique ID Generation**

- Introduced the `generate_unique_id` function to atomically manage the creation of unique IDs for NFTs.
- Ensures thread-safe incrementation of `next_id` during minting operations.

---

### 3. **Improved Error Messages**

- Enhanced error messages across functions to make them more descriptive and user-friendly.
- Example: Replaced "Insufficient balance" with "Your account does not have enough balance to complete this purchase."

---

### 4. **Zero Price Handling**

- Prevented minting of NFTs with a price of zero.
- Disallowed setting a resale price of zero, as it could create invalid transactions.

---

### 5. **Secure Balance Updates**

- During NFT purchase, validated the buyer's balance before proceeding with the transaction.
- Adjusted logic to securely debit the buyer's balance and credit the creator's balance.
- Implemented better handling of creator royalties:
    - Ensures royalties are always calculated and credited correctly.

---

### 6. **Thread Safety**

- Centralized state modifications (e.g., `next_id` incrementation, NFT insertion) into well-defined sections to avoid potential race conditions.

---

### 7. **New Helper Functions**

- **`validate_input`**: Validates title, description, and price for minting NFTs.
- **`generate_unique_id`**: Ensures thread-safe and atomic generation of unique IDs for new NFTs.

---

### 8. **Robust Royalty Management**

- Ensured royalties are consistently calculated and credited during NFT purchase.
- Adjusted the creator's royalty balance with proper error handling.

---

### 9. **Enhanced Error Handling**

- Added checks to ensure operations (e.g., purchasing, setting resale price) can only be performed on existing and valid NFTs.
- Provided clear feedback for actions such as:
    - Attempting to deactivate a non-existent NFT.
    - Attempting to purchase an inactive NFT.

---

### 10. **Optimized Logic**

- Simplified filtering logic for retrieving active NFTs, user-owned NFTs, etc., to make it more efficient and concise.
- Reduced redundant state accesses by caching results where appropriate.

---

### 11. **Code Readability & Maintainability**

- Improved readability by organizing functions logically and using meaningful variable names.
- Added comments to explain key sections of the code for better maintainability.

---

### ### **transfer_nft_ownership**:

1. **Ownership Validation**: Ensures only the current owner can initiate the transfer.
2. **Active NFT Requirement**: Prevents transfer of inactive NFTs.
3. **New Owner Check**: Verifies that the new owner is not the same as the current owner.
4. **Reset Resale Price**: Automatically resets any existing resale price when ownership is transferred.

---

### Usage Example:

- Current owner calls the function to transfer an NFT to another user.
- E.g., `transfer_nft_ownership(1, new_owner_principal)` transfers NFT with ID `1` to `new_owner_principal`.

---

Adding this feature enhances the flexibility of the system, supporting peer-to-peer transactions and ownership changes without requiring a purchase.

These changes collectively improve the robustness, security, performance, and clarity of the code while preserving its intended functionality.